### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,9 +33,9 @@ jobs:
       run: make gen git/diff
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.1.6
+        version: v2.1
         args: ./... ./internal/cmd/generate/...
 
     - run: go install github.com/google/addlicense@latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 jobs:
 
@@ -34,7 +35,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: latest
+        version: v2.1.6
         args: ./... ./internal/cmd/generate/...
 
     - run: go install github.com/google/addlicense@latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,24 @@
+version: "2"
 linters:
-  # Defaults, plus:
   enable:
-  - errname
-  - errorlint
-  - exportloopref
-  - gocritic
-  - godot
-  - goheader
-  - goimports
-  - gosec
-  - lll
-  - makezero
-  - misspell
-  - nilerr
-  - nilnil
-  - nolintlint
-  - prealloc
-  - revive
-  - unconvert
-  - unparam
-  - whitespace
+    - errname
+    - errorlint
+    - gocritic
+    - godot
+    - goheader
+    - gosec
+    - lll
+    - makezero
+    - misspell
+    - nilerr
+    - nilnil
+    - nolintlint
+    - prealloc
+    - revive
+    - unconvert
+    - unparam
+    - whitespace
+
+formatters:
+  enable:
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ ADDLICENSE_FLAGS ?= -c 'Alan Parra' -l mit -ignore '**/*.yml'
 .PHONY: all
 all: build
 
+# ci partly mimics CI checks.
+# Does not run `fix` or `gen` targets to avoid dirtying the local workspace.
+.PHONY: ci
+ci: build test lint
+
 .PHONY: clean
 clean:
 	rm -f cover.out generate

--- a/gen.go
+++ b/gen.go
@@ -17,5 +17,6 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-//go:generate go run ./internal/cmd/generate -o semerr.gen.go
 package semerr
+
+//go:generate go run ./internal/cmd/generate -o semerr.gen.go

--- a/internal/cmd/generate/main.go
+++ b/internal/cmd/generate/main.go
@@ -119,6 +119,7 @@ func run() error {
 		out = os.Stdout
 	} else {
 		var err error
+		//nolint:gosec // File permissions are fine at 644.
 		out, err = os.OpenFile(*outFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			return err

--- a/semerr_test.go
+++ b/semerr_test.go
@@ -29,18 +29,17 @@ import (
 func TestFrom_unmapped(t *testing.T) {
 	err1 := errors.New("an error")
 
-	fromCode := func(n interface{}, err error) error {
-		c := semerr.Code(n.(int))
+	fromCode := func(n int, err error) error {
+		//nolint:gosec // Interger overflow is not a problem here.
+		c := semerr.Code(n)
 		return semerr.FromGRPCCode(c, err)
 	}
-	fromHTTP := func(s interface{}, err error) error {
-		return semerr.FromHTTPStatus(s.(int), err)
-	}
+	fromHTTP := semerr.FromHTTPStatus
 
 	tests := []struct {
 		name string
-		fn   func(interface{}, error) error
-		in   interface{}
+		fn   func(int, error) error
+		in   int
 	}{
 		{
 			name: "FromGRPCCode(OK, $err)",


### PR DESCRIPTION
Update golangci-lint to v2, migrating the config in the process.